### PR TITLE
Zcu102 vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,46 @@ wpa_supplicant -B -i wlan0 -c /etc/wpa_supplicant.conf
 iw wlan0 link
 dhclient wlan0
 ```
+
+## zynqmp configuration
+
+One linux binary is provided, built from petalinux 2017.3. Only the secondary serial port is passed
+though to the VM.
+
+### building a new linux image
+
+These instructions assume the user has installed petalinux.
+
+NOTE: Petalinux 2017.4 can cause issues.
+
+First, create a new project using the petalinux BSP:
+
+```
+cd ~
+petalinux-create -t project -s xilinx-zcu102-v2017.3-final.bsp
+cd xilinx-zcu102-2017.3
+```
+
+Next, modify the project so that Linux will start a getty for either serial device. Add the
+following to `project-spec/meta-user/conf/layer.conf`:
+
+```
+require conf/distro/include/console.inc
+```
+
+Now, create the file `project-spec/meta-user/conf/distro/include/console.inc` with the following
+line:
+
+```
+SERIAL_CONSOLES_append = " 115200;ttyPS1"
+```
+
+Now call `petalinux-build` to compile the image. The Linux image should exist in `images/linux/Image`.
+
+At this point, petalinux can be used to add additional modules and other pieces to Linux.
+
+### initializing
+
+```
+../init-build.sh -DCAMKES_VM_APP=vm_minimal -DPLATFORM=zynqmp -DCROSS_COMPILER_PREFIX=aarch64-linux-gnu- -DAARCH64=true
+```

--- a/apps/vm_minimal/CMakeLists.txt
+++ b/apps/vm_minimal/CMakeLists.txt
@@ -75,6 +75,21 @@ elseif("${KernelARMPlatform}" STREQUAL "tx2")
     AddToFileServer("linux" "${CMAKE_SOURCE_DIR}/projects/camkes-vm-images/tx2/linux")
     AddToFileServer("linux-dtb" "${CMAKE_SOURCE_DIR}/projects/camkes-vm-images/tx2/linux-dtb")
 
+elseif("${KernelARMPlatform}" STREQUAL "zynqmp")
+    AddToFileServer("linux" "${CMAKE_SOURCE_DIR}/projects/camkes-vm-images/zynqmp/linux")
+
+    set(device_tree_src "${CMAKE_SOURCE_DIR}/projects/camkes-vm-images/zynqmp/linux.dts")
+
+    add_custom_command(
+        OUTPUT linux/linux-dtb
+        COMMAND
+            bash -c "which dtc && dtc -I dts -O dtb ${device_tree_src} > ${CMAKE_CURRENT_BINARY_DIR}/linux/linux-dtb"
+        VERBATIM
+    )
+    # Create custom target for setting the dtb
+    add_custom_target(set_dtb DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/linux/linux-dtb")
+    AddToFileServer("linux-dtb" "${CMAKE_CURRENT_BINARY_DIR}/linux/linux-dtb" DEPENDS set_dtb)
+
 endif()
 
 AddCamkesCPPFlag(cpp_flags CONFIG_VARS VmEmmc2NoDMA VmVUSB VmVchan Tk1DeviceFwd Tk1Insecure)

--- a/apps/vm_minimal/settings.cmake
+++ b/apps/vm_minimal/settings.cmake
@@ -10,7 +10,7 @@
 # @TAG(DATA61_BSD)
 #
 
-set(supported "tk1;tx1;tx2;exynos5422")
+set(supported "tk1;tx1;tx2;exynos5422;zynqmp")
 if(NOT "${PLATFORM}" IN_LIST supported)
     message(FATAL_ERROR "PLATFORM: ${PLATFORM} not supported.
          Supported: ${supported}")

--- a/apps/vm_minimal/zynqmp/devices.camkes
+++ b/apps/vm_minimal/zynqmp/devices.camkes
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DORNERWORKS_BSD)
+ */
+
+#include <configurations/vm.h>
+
+#define VM_INITRD_MAX_SIZE 0x01900000 //25 MB
+#define VM_RAM_BASE 0x800000000
+#define VM_PADDR_RAM_BASE 0x800000000
+#define VM_RAM_SIZE 0x10000000
+#define VM_RAM_OFFSET 0
+#define VM_DTB_ADDR 0x80C000000
+#define VM_INITRD_ADDR 0x80A700000 //(DTB_ADDR - INITRD_MAX_SIZE)
+
+assembly {
+    composition {}
+    configuration {
+
+        vm0.linux_address_config = {
+            "linux_ram_base" : VAR_STRINGIZE(VM_RAM_BASE),
+            "linux_ram_paddr_base" : VAR_STRINGIZE(VM_PADDR_RAM_BASE),
+            "linux_ram_size" : VAR_STRINGIZE(VM_RAM_SIZE),
+            "linux_ram_offset" : VAR_STRINGIZE(VM_RAM_OFFSET),
+            "dtb_addr" : VAR_STRINGIZE(VM_DTB_ADDR),
+            "initrd_max_size" : VAR_STRINGIZE(VM_INITRD_MAX_SIZE),
+            "initrd_addr" : VAR_STRINGIZE(VM_INITRD_ADDR)
+        };
+
+        vm0.dtb = dtb([{"path": "/serial@ff010000"},
+                          ]);
+
+        vm0.untyped_mmios = [
+            "0xf9060000:12", // Interrupt Controller Virtual CPU interface (Virtual Machine view)
+            ];
+
+        vm0.irqs =  [
+            27, // VTCNT (arch timer)
+            ];
+    }
+}

--- a/components/VM/plat_include/zynqmp/plat/vmlinux.h
+++ b/components/VM/plat_include/zynqmp/plat/vmlinux.h
@@ -166,15 +166,4 @@ static const int linux_pt_irqs[] = {
     INTERRUPT_CORE_VIRT_TIMER,
 };
 
-#define LINUX_RAM_BASE       (0x800000000)
-#define LINUX_RAM_END        (0x810000000)
-#define LINUX_RAM_SIZE       (LINUX_RAM_END - LINUX_RAM_BASE)
-#define LINUX_RAM_PADDR_BASE LINUX_RAM_BASE
-
-/* the offset between actual physcial memory and guest physical memory */
-#define LINUX_RAM_OFFSET  (0)
-#define DTB_ADDR          (LINUX_RAM_BASE + 0x0C000000)
-#define INITRD_MAX_SIZE   0x01900000 //25 MB
-#define INITRD_ADDR       (DTB_ADDR - INITRD_MAX_SIZE) //0x80A700000
-
 #endif /* VMLINUX_H */

--- a/components/VM/plat_include/zynqmp/plat/vmlinux.h
+++ b/components/VM/plat_include/zynqmp/plat/vmlinux.h
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DORNERWORKS_BSD)
+ */
+#ifndef VMLINUX_ZYNQMP_H
+#define VMLINUX_ZYNQMP_H
+
+#include <sel4arm-vmm/vm.h>
+
+#define INTERRUPT_CORE_VIRT_MAINT         25
+#define INTERRUPT_CORE_HYP_TIMER          26
+#define INTERRUPT_CORE_VIRT_TIMER         27
+#define INTERRUPT_CORE_LEGACY_FIQ         28
+#define INTERRUPT_CORE_SEC_PHYS_TIMER     29
+#define INTERRUPT_CORE_NONSEC_PHYS_TIMER  30
+#define INTERRUPT_CORE_LEGACY_IRQ         31
+#define INTERRUPT_RPU0_APM                40
+#define INTERRUPT_RPU1_APM                41
+#define INTERRUPT_OCM                     42
+#define INTERRUPT_LPD_APB                 43
+#define INTERRUPT_RPU0_ECC                44
+#define INTERRUPT_RPU1_ECC                45
+#define INTERRUPT_NAND                    46
+#define INTERRUPT_QSPI                    47
+#define INTERRUPT_GPIO                    48
+#define INTERRUPT_I2C0                    49
+#define INTERRUPT_I2C1                    50
+#define INTERRUPT_SPI0                    51
+#define INTERRUPT_SPI1                    52
+#define INTERRUPT_UART0                   53
+#define INTERRUPT_UART1                   54
+#define INTERRUPT_CAN0                    55
+#define INTERRUPT_CAN1                    56
+#define INTERRUPT_LPD_APM                 57
+#define INTERRUPT_RTC_ALARM               58
+#define INTERRUPT_RTC_SECONDS             59
+#define INTERRUPT_CLKMON                  60
+#define INTERRUPT_IPI_CH7                 61
+#define INTERRUPT_IPI_CH8                 62
+#define INTERRUPT_IPI_CH9                 63
+#define INTERRUPT_IPI_CH10                64
+#define INTERRUPT_IPI_CH2                 65
+#define INTERRUPT_IPI_CH1                 66
+#define INTERRUPT_IPI_CH0                 67
+#define INTERRUPT_TTC0_0                  68
+#define INTERRUPT_TTC0_1                  69
+#define INTERRUPT_TTC0_2                  70
+#define INTERRUPT_TTC1_0                  71
+#define INTERRUPT_TTC1_1                  72
+#define INTERRUPT_TTC1_2                  73
+#define INTERRUPT_TTC2_0                  74
+#define INTERRUPT_TTC2_1                  75
+#define INTERRUPT_TTC2_2                  76
+#define INTERRUPT_TTC3_0                  77
+#define INTERRUPT_TTC3_1                  78
+#define INTERRUPT_TTC3_2                  79
+#define INTERRUPT_SDIO0                   80
+#define INTERRUPT_SDIO1                   81
+#define INTERRUPT_SDIO0_WAKEUP            82
+#define INTERRUPT_SDIO1_WAKEUP            83
+#define INTERRUPT_LPD_SWDT                84
+#define INTERRUPT_CSU_SWDT                85
+#define INTERRUPT_LPD_ATB                 86
+#define INTERRUPT_AIB                     87
+#define INTERRUPT_SYSMON                  88
+#define INTERRUPT_GEM0                    89
+#define INTERRUPT_GEM0_WAKEUP             90
+#define INTERRUPT_GEM1                    91
+#define INTERRUPT_GEM1_WAKEUP             92
+#define INTERRUPT_GEM2                    93
+#define INTERRUPT_GEM2_WAKEUP             94
+#define INTERRUPT_GEM3                    95
+#define INTERRUPT_GEM3_WAKEUP             96
+#define INTERRUPT_USB0_ENDPOINT_0         97
+#define INTERRUPT_USB0_ENDPOINT_1         98
+#define INTERRUPT_USB0_ENDPOINT_2         99
+#define INTERRUPT_USB0_ENDPOINT_3         100
+#define INTERRUPT_USB0_OTG                101
+#define INTERRUPT_USB1_ENDPOINT_0         102
+#define INTERRUPT_USB1_ENDPOINT_1         103
+#define INTERRUPT_USB1_ENDPOINT_2         104
+#define INTERRUPT_USB1_ENDPOINT_3         105
+#define INTERRUPT_USB1_OTG                106
+#define INTERRUPT_USB0_WAKEUP             107
+#define INTERRUPT_USB1_WAKEUP             108
+#define INTERRUPT_LPD_DMA_0               109
+#define INTERRUPT_LPD_DMA_1               110
+#define INTERRUPT_LPD_DMA_2               111
+#define INTERRUPT_LPD_DMA_3               112
+#define INTERRUPT_LPD_DMA_4               113
+#define INTERRUPT_LPD_DMA_5               114
+#define INTERRUPT_LPD_DMA_6               115
+#define INTERRUPT_LPD_DMA_7               116
+#define INTERRUPT_CSU                     117
+#define INTERRUPT_CSU_DMA                 118
+#define INTERRUPT_EFUSE                   119
+#define INTERRUPT_XPPU                    120
+#define INTERRUPT_PL_PS_GROUP0_0          121
+#define INTERRUPT_PL_PS_GROUP0_1          122
+#define INTERRUPT_PL_PS_GROUP0_2          123
+#define INTERRUPT_PL_PS_GROUP0_3          124
+#define INTERRUPT_PL_PS_GROUP0_4          125
+#define INTERRUPT_PL_PS_GROUP0_5          126
+#define INTERRUPT_PL_PS_GROUP0_6          127
+#define INTERRUPT_PL_PS_GROUP0_7          128
+#define INTERRUPT_PL_PS_GROUP1_0          136
+#define INTERRUPT_PL_PS_GROUP1_1          137
+#define INTERRUPT_PL_PS_GROUP1_2          138
+#define INTERRUPT_PL_PS_GROUP1_3          139
+#define INTERRUPT_PL_PS_GROUP1_4          140
+#define INTERRUPT_PL_PS_GROUP1_5          141
+#define INTERRUPT_PL_PS_GROUP1_6          142
+#define INTERRUPT_PL_PS_GROUP1_7          143
+#define INTERRUPT_DDR                     144
+#define INTERRUPT_FPD_SWDT                145
+#define INTERRUPT_PCIE_MSI0               146
+#define INTERRUPT_PCIE_MSI1               147
+#define INTERRUPT_PCIE_INTX               148
+#define INTERRUPT_PCIE_DMA                149
+#define INTERRUPT_PCIE_MSC                150
+#define INTERRUPT_DISPLAYPORT             151
+#define INTERRUPT_FPD_APB                 152
+#define INTERRUPT_FPD_ATB                 153
+#define INTERRUPT_DPDMA                   154
+#define INTERRUPT_FPD_ATM                 155
+#define INTERRUPT_FPD_DMA_0               156
+#define INTERRUPT_FPD_DMA_1               157
+#define INTERRUPT_FPD_DMA_2               158
+#define INTERRUPT_FPD_DMA_3               159
+#define INTERRUPT_FPD_DMA_4               160
+#define INTERRUPT_FPD_DMA_5               161
+#define INTERRUPT_FPD_DMA_6               162
+#define INTERRUPT_FPD_DMA_7               163
+#define INTERRUPT_GPU                     164
+#define INTERRUPT_SATA                    165
+#define INTERRUPT_FPD_XMPU                166
+#define INTERRUPT_APU_VCPUMNT_0           167
+#define INTERRUPT_APU_VCPUMNT_1           168
+#define INTERRUPT_APU_VCPUMNT_2           169
+#define INTERRUPT_APU_VCPUMNT_3           170
+#define INTERRUPT_CPU_CTI_0               171
+#define INTERRUPT_CPU_CTI_1               172
+#define INTERRUPT_CPU_CTI_2               173
+#define INTERRUPT_CPU_CTI_3               174
+#define INTERRUPT_PMU_COMM_0              175
+#define INTERRUPT_PMU_COMM_1              176
+#define INTERRUPT_PMU_COMM_2              177
+#define INTERRUPT_PMU_COMM_3              178
+#define INTERRUPT_APU_COMM_0              179
+#define INTERRUPT_APU_COMM_1              180
+#define INTERRUPT_APU_COMM_2              181
+#define INTERRUPT_APU_COMM_3              182
+#define INTERRUPT_L2_CACHE                183
+#define INTERRUPT_APU_EXTERROR            184
+#define INTERRUPT_APU_REGERROR            185
+#define INTERRUPT_CCI                     186
+#define INTERRUPT_SMMU                    187
+#define MAX_IRQ                           200
+
+static const int linux_pt_irqs[] = {
+    INTERRUPT_CORE_VIRT_TIMER,
+};
+
+#define LINUX_RAM_BASE       (0x800000000)
+#define LINUX_RAM_END        (0x810000000)
+#define LINUX_RAM_SIZE       (LINUX_RAM_END - LINUX_RAM_BASE)
+#define LINUX_RAM_PADDR_BASE LINUX_RAM_BASE
+
+/* the offset between actual physcial memory and guest physical memory */
+#define LINUX_RAM_OFFSET  (0)
+#define DTB_ADDR          (LINUX_RAM_BASE + 0x0C000000)
+#define INITRD_MAX_SIZE   0x01900000 //25 MB
+#define INITRD_ADDR       (DTB_ADDR - INITRD_MAX_SIZE) //0x80A700000
+
+#endif /* VMLINUX_H */

--- a/components/VM/src/main.c
+++ b/components/VM/src/main.c
@@ -403,8 +403,8 @@ static int vmm_init(void)
             cspacepath_t path;
             vka_cspace_make_path(vka, cap, &path);
             int utType = ALLOCMAN_UT_DEV;
-            if (paddr >= LINUX_RAM_PADDR_BASE &&
-                paddr <= (LINUX_RAM_PADDR_BASE + (LINUX_RAM_SIZE - 1))) {
+            if (paddr >= linux_ram_paddr_base &&
+                paddr <= (linux_ram_paddr_base + (linux_ram_size - 1))) {
                 utType = ALLOCMAN_UT_DEV_MEM;
             }
             err = allocman_utspace_add_uts(allocman, 1, &path, &size, &paddr, utType);

--- a/components/VM/src/main.c
+++ b/components/VM/src/main.c
@@ -715,7 +715,7 @@ void *install_vm_module(vm_t *vm, const char *kernel_name, enum img_type file_ty
     }
     switch (ret_file_type) {
     case IMG_BIN:
-        if (config_set(CONFIG_PLAT_TX1) || config_set(CONFIG_PLAT_TX2)) {
+        if (config_set(CONFIG_PLAT_TX1) || config_set(CONFIG_PLAT_TX2) || config_set(CONFIG_PLAT_ZYNQMP)) {
             /* This is likely an aarch64/aarch32 linux difference */
             load_addr = linux_ram_base + 0x80000;
         } else {

--- a/components/VM/src/main.c
+++ b/components/VM/src/main.c
@@ -795,7 +795,7 @@ static int load_linux(vm_t *vm, const char *kernel_name, const char *dtb_name, c
     }
 
     /* Set boot arguments */
-    err = vm_set_bootargs(vm, entry, MACH_TYPE, (uint32_t) dtb);
+    err = vm_set_bootargs(vm, entry, MACH_TYPE, dtb);
     if (err) {
         printf("Error: Failed to set boot arguments\n");
         return -1;

--- a/components/VM/src/modules/plat/zynqmp/init.c
+++ b/components/VM/src/modules/plat/zynqmp/init.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DORNERWORKS_BSD)
+ */
+#include <autoconf.h>
+
+#include <vmlinux.h>
+
+#include <sel4arm-vmm/vm.h>
+#include <sel4arm-vmm/plat/devices.h>
+
+#include <camkes.h>
+
+static const struct device *linux_pt_devices[] = {
+    &dev_uart1,
+};
+
+static const struct device *linux_ram_devices[] = {
+
+};
+
+static void
+plat_init_module(vm_t* vm, void *cookie)
+{
+    int err;
+
+    /* Install pass-through devices */
+    for (int i = 0; i < sizeof(linux_pt_devices) / sizeof(*linux_pt_devices); i++) {
+        err = vm_install_passthrough_device(vm, linux_pt_devices[i]);
+        assert(!err);
+    }
+}
+
+DEFINE_MODULE(plat, NULL, plat_init_module)


### PR DESCRIPTION
This adds camkes-arm-vm support for the zynqmp.

The changes are pretty self explanatory, and I added a commit to clean up some compiler warnings. Also, the DTB address was getting truncated, which caused Linux to fail since it gets loaded into high memory regions.

This also relies upon the other numerous PRs that I've opened up.

Let me know if you have any questions.